### PR TITLE
Update LINE Login custom auth sample to use firebase-admin

### DIFF
--- a/Line/README.md
+++ b/Line/README.md
@@ -14,7 +14,7 @@ This sample shows how to Sign in Firebase using [LINE Login](https://developers.
     * Android Package Signature: The SHA1 value of your keystore, without semicolons
   * Download the LINE SDK for iOS and Android from LINE developers site and add them to your apps. The latest version of LINE SDK may have different API with that used to create the sample app, so you may need to make some changes to the sample apps. LINE SDK versions being used in building the sample apps are:
     *  iOS: **3.2.1**
-    *  Android: **3.1.20** 
+    *  Android: **3.1.21** 
   * Update your Channel ID to your apps
     * iOS: Update `<your_channel_id>` in `LineAdapter.plist`
     * Android: Update `<your_channel_id>` in `app/build.gradle` 

--- a/Line/android/LINELoginDemo/app/build.gradle
+++ b/Line/android/LINELoginDemo/app/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 
 android {
-    compileSdkVersion 24
-    buildToolsVersion "24.0.2"
+    compileSdkVersion 25
+    buildToolsVersion "25.0.0"
     defaultConfig {
         applicationId "com.google.firebase.linelogindemo"
         minSdkVersion 15
-        targetSdkVersion 24
+        targetSdkVersion 25
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
@@ -30,9 +30,9 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
 
-    compile 'com.android.support:appcompat-v7:24.2.1'
+    compile 'com.android.support:appcompat-v7:25.1.0'
     compile 'com.android.volley:volley:1.0.0'
-    compile 'com.google.firebase:firebase-auth:9.4.0'
+    compile 'com.google.firebase:firebase-auth:10.0.1'
 
     testCompile 'junit:junit:4.12'
 }

--- a/Line/android/LINELoginDemo/app/src/main/java/com/google/firebase/linelogindemo/activity/MainActivity.java
+++ b/Line/android/LINELoginDemo/app/src/main/java/com/google/firebase/linelogindemo/activity/MainActivity.java
@@ -30,6 +30,7 @@ import com.android.volley.toolbox.ImageLoader;
 import com.android.volley.toolbox.NetworkImageView;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.Task;
+import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.linelogindemo.R;
@@ -95,9 +96,9 @@ public class MainActivity extends AppCompatActivity {
         // Kick start login progress
         mLineLoginHelper
                 .startLineLogin()
-                .addOnCompleteListener(new OnCompleteListener<FirebaseUser>() {
+                .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
                     @Override
-                    public void onComplete(@NonNull Task<FirebaseUser> task) {
+                    public void onComplete(@NonNull Task<AuthResult> task) {
                         updateUI();
                         mLoadingDialog.dismiss();
                         mLoadingDialog = null;

--- a/Line/android/LINELoginDemo/build.gradle
+++ b/Line/android/LINELoginDemo/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.0'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/Line/iOS/LINELoginDemo/LINELoginDemo.xcodeproj/project.pbxproj
+++ b/Line/iOS/LINELoginDemo/LINELoginDemo.xcodeproj/project.pbxproj
@@ -246,7 +246,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n";
 			showEnvVarsInLog = 0;
 		};
 		E59DDBD5F8ABB7CD5602FD25 /* [CP] Embed Pods Frameworks */ = {

--- a/Line/iOS/LINELoginDemo/LINELoginDemo/LineAuthManager.m
+++ b/Line/iOS/LINELoginDemo/LINELoginDemo/LineAuthManager.m
@@ -142,49 +142,9 @@
 - (void)authenticateWithFirebaseToken:(NSString *)firebaseToken {
     // STEP 3: Login to Firebase using Firebase Custom Auth token
     [[FIRAuth auth] signInWithCustomToken:firebaseToken completion:^(FIRUser * _Nullable user, NSError * _Nullable error) {
-        if (error) {
-            [self returnSignInResult:nil error:error];
-            return;
-        }
-        
-        // Try to update
-        [self updateUserProfile:user];
+        [self returnSignInResult:user error:error];
     }];
 }
-
-#pragma mark - Step 4: (Optional) Update user profile with LINE Profile
-- (void)updateUserProfile:(FIRUser *)user {
-    BOOL isProfileNeededUpdate = (user.displayName.length == 0) || (user.photoURL.absoluteString.length == 0);
-    if (!isProfileNeededUpdate) {
-        [self returnSignInResult:user error:nil];
-    }
-    
-    // STEP 4: (Optional) Update user profile with LINE Profile
-    __weak typeof(self) wSelf = self;
-    [self.lineAdapter.getLineApiClient getMyProfileWithResultBlock:^(NSDictionary *aResult, NSError *aError) {
-        if (aError) {
-            // As this step is optional in this sample, we don't return the error to the view controller
-            [wSelf returnSignInResult:user error:nil];
-            return;
-        }
-        
-        // Update Firebase profile with LINE profile
-        FIRUserProfileChangeRequest *request = user.profileChangeRequest;
-        request.displayName = aResult[@"displayName"];
-        if (aResult[@"pictureUrl"]) {
-            request.photoURL = [NSURL URLWithString:aResult[@"pictureUrl"]];
-        }
-        [request commitChangesWithCompletion:^(NSError * _Nullable error) {
-            if (error) {
-                // Handle error here
-            }
-            
-            // As this step is optional in this sample, we don't return the error to the view controller
-            [wSelf returnSignInResult:user error:nil];
-        }];
-    }];
-}
-
 
 #pragma mark - Sign out
 - (void)signOut {

--- a/Line/iOS/LINELoginDemo/Podfile
+++ b/Line/iOS/LINELoginDemo/Podfile
@@ -6,6 +6,6 @@ target 'LINELoginDemo' do
   # use_frameworks!
 
   # Pods for LINELoginDemo
-  pod 'Firebase/Auth', '3.7.1'
+  pod 'Firebase/Auth', '3.11.0'
   pod 'GTMHTTPFetcher', '2.0.0'
 end

--- a/Line/iOS/LINELoginDemo/Podfile.lock
+++ b/Line/iOS/LINELoginDemo/Podfile.lock
@@ -1,30 +1,37 @@
 PODS:
-  - Firebase/Auth (3.7.1):
+  - Firebase/Auth (3.11.0):
     - Firebase/Core
-    - FirebaseAuth (= 3.0.5)
-  - Firebase/Core (3.7.1):
-    - FirebaseAnalytics (= 3.4.4)
-    - FirebaseCore (= 3.4.3)
-  - FirebaseAnalytics (3.4.4):
+    - FirebaseAuth (= 3.1.0)
+  - Firebase/Core (3.11.0):
+    - FirebaseAnalytics (= 3.6.0)
+    - FirebaseCore (= 3.4.6)
+  - FirebaseAnalytics (3.6.0):
     - FirebaseCore (~> 3.4)
     - FirebaseInstanceID (~> 1.0)
     - GoogleInterchangeUtilities (~> 1.2)
     - GoogleSymbolUtilities (~> 1.1)
-  - FirebaseAuth (3.0.5):
-    - FirebaseAnalytics (~> 3.3)
-    - GoogleNetworkingUtilities (~> 1.2)
-    - GoogleUtilities (~> 1.2)
-  - FirebaseCore (3.4.3):
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
+  - FirebaseAuth (3.1.0):
+    - FirebaseAnalytics (~> 3.6)
+    - GoogleToolboxForMac/NSDictionary+URLArguments (~> 2.1)
+    - GTMSessionFetcher/Core (~> 1.1)
+  - FirebaseCore (3.4.6):
     - GoogleInterchangeUtilities (~> 1.2)
-    - GoogleUtilities (~> 1.2)
+    - GoogleToolboxForMac/NSData+zlib (~> 2.1)
   - FirebaseInstanceID (1.0.8)
   - GoogleInterchangeUtilities (1.2.2):
     - GoogleSymbolUtilities (~> 1.1)
-  - GoogleNetworkingUtilities (1.2.2):
-    - GoogleSymbolUtilities (~> 1.1)
   - GoogleSymbolUtilities (1.1.2)
-  - GoogleUtilities (1.3.2):
-    - GoogleSymbolUtilities (~> 1.1)
+  - GoogleToolboxForMac/DebugUtils (2.1.0):
+    - GoogleToolboxForMac/Defines (= 2.1.0)
+  - GoogleToolboxForMac/Defines (2.1.0)
+  - GoogleToolboxForMac/NSData+zlib (2.1.0):
+    - GoogleToolboxForMac/Defines (= 2.1.0)
+  - GoogleToolboxForMac/NSDictionary+URLArguments (2.1.0):
+    - GoogleToolboxForMac/DebugUtils (= 2.1.0)
+    - GoogleToolboxForMac/Defines (= 2.1.0)
+    - GoogleToolboxForMac/NSString+URLArguments (= 2.1.0)
+  - GoogleToolboxForMac/NSString+URLArguments (2.1.0)
   - GTMHTTPFetcher (2.0.0):
     - GTMHTTPFetcher/Fetcher (= 2.0.0)
     - GTMHTTPFetcher/Logging (= 2.0.0)
@@ -44,23 +51,24 @@ PODS:
     - GTMHTTPFetcher/Service (= 2.0.0)
   - GTMHTTPFetcher/Service (2.0.0):
     - GTMHTTPFetcher/Fetcher (= 2.0.0)
+  - GTMSessionFetcher/Core (1.1.7)
 
 DEPENDENCIES:
-  - Firebase/Auth (= 3.7.1)
+  - Firebase/Auth (= 3.11.0)
   - GTMHTTPFetcher (= 2.0.0)
 
 SPEC CHECKSUMS:
-  Firebase: be473484f0d515e72ffd04acf22f981773c23e58
-  FirebaseAnalytics: 0533a00b681e08fd0b2cd0444b7ddf0ef9fd7a1a
-  FirebaseAuth: 75a062bbf2d3c97d1e6e55bbc110e13a6853e25d
-  FirebaseCore: 5a885548bbc5f0c410b04f8e9ac9d73ff1221907
+  Firebase: b8134e285eb33201115bc688bc5d7f112923bc1f
+  FirebaseAnalytics: 9c67af0ebeb8d2146c9b4ea2616439affa947b58
+  FirebaseAuth: b436e4ecebe068bf8e8c6e4e29de5756ffe7ee24
+  FirebaseCore: 03da1cb32615569bbc2830a22f9ad753d9a02ef5
   FirebaseInstanceID: ba1e640935235e5fac39dfa816fe7660e72e1a8a
   GoogleInterchangeUtilities: d5bc4d88d5b661ab72f9d70c58d02ca8c27ad1f7
-  GoogleNetworkingUtilities: 3edd3a8161347494f2da60ea0deddc8a472d94cb
   GoogleSymbolUtilities: 631ee17048aa5e9ab133470d768ea997a5ef9b96
-  GoogleUtilities: 8bbc733218aad26306f9d4a253823986110e3358
+  GoogleToolboxForMac: 2b2596cbb7186865e98cadf2b1e262d851c2b168
   GTMHTTPFetcher: a14e4ce88b3387be1cf569c24f316c3a7faeb43c
+  GTMSessionFetcher: a1f8ed39e4fe21c68957daed472c7afbcdf29166
 
-PODFILE CHECKSUM: d9ed9c0cca80727dfbdcc832f46bae3c2a276444
+PODFILE CHECKSUM: c3f2060a74b9f6b5079907937adf114627105760
 
-COCOAPODS: 1.0.1
+COCOAPODS: 1.1.1

--- a/Line/server/app.js
+++ b/Line/server/app.js
@@ -16,28 +16,115 @@
 'use strict';
 
 // Modules imports
-const request = require('request');
+const rp = require('request-promise');
 const express = require('express');
 const bodyParser = require('body-parser');
 
 // Firebase Setup
-const firebase = require('firebase');
-firebase.initializeApp({
-  serviceAccount: 'service-account.json'
+const admin = require('firebase-admin');
+const serviceAccount = require('./service-account.json');
+admin.initializeApp({
+  credential: admin.credential.cert(serviceAccount)
 });
 
 // Load config file
 const config = require('./config.json');
 
-// Generate Firebase Custom Auth token
-function generateFirebaseToken(lineMid) {
-  // The UID we'll assign to the user.
+// Generate a Request option to access LINE APIs
+function generateLineApiRequest(apiEndpoint, lineAccessToken) {
+  return {
+    url: apiEndpoint,
+    headers: {
+      'Authorization': `Bearer ${lineAccessToken}`
+    },
+    json: true
+  };
+}
+
+/**
+ * Look up Firebase user based on LINE's mid. If the Firebase user does not exist,
+ + fetch LINE profile and create a new Firebase user with it.
+ *
+ * @returns {Promise<UserRecord>} The Firebase user record in a promise.
+ */
+function getFirebaseUser(lineMid, lineAccessToken) {
+  // Generate Firebase user's uid based on LINE's mid
   const firebaseUid = `line:${lineMid}`;
 
-  // Create the custom token.
-  const token = firebase.auth().createCustomToken(firebaseUid);
-  console.log('Created Custom token for UID "', firebaseUid, '" Token:', token);
-  return token;
+  // LINE's get user profile API endpoint
+  const getProfileOptions = generateLineApiRequest('https://api.line.me/v1/profile', lineAccessToken);
+
+  return new Promise(function (fulfill, reject){
+    // Check if corresponding Firebase user already existed
+    admin.auth().getUser(firebaseUid)
+      .then(userRecord => fulfill(userRecord))
+      .catch(error => {
+        // If user does not exist, fetch LINE profile and create a Firebase new user with it
+        if (error.code === 'auth/user-not-found') {
+          return rp(getProfileOptions)
+            .then(response => {
+              // Parse user profile from LINE's get user profile API response
+              const displayName = response.displayName;
+              const photoURL = response.pictureUrl;
+
+              // Create a new Firebase user with LINE profile and return it
+              return admin.auth().createUser({
+                uid: firebaseUid,
+                displayName: displayName,
+                photoURL: photoURL
+              });
+            })
+            .then(userRecord => fulfill(userRecord))
+            .catch(error => reject(error));
+          }
+
+        // If error other than auth/user-not-found occurred, fail the whole login process
+        return reject(error);
+      });
+  });
+}
+
+/**
+ * Verify LINE access token and return a custom auth token allowing signing-in 
+ * the corresponding Firebase account.
+ *
+ * Here are the steps involved:
+ *  1. Verify with LINE server that a LINE access token is valid
+ *  2. Check if a Firebase user corresponding to the LINE user already existed.
+ *  If not, fetch user profile from LINE and generate a corresponding Firebase user.
+ *  3. Return a custom auth token allowing signing-in the Firebase account.
+ *
+ * @returns {Promise<string>} The Firebase custom auth token in a promise.
+ */
+function verifyLineToken(lineAccessToken) {
+  // Send request to LINE server for access token verification
+  const verifyTokenOptions = generateLineApiRequest('https://api.line.me/v1/oauth/verify', lineAccessToken);
+  var firebaseUid = '';
+
+  // STEP 1: Verify with LINE server that a LINE access token is valid
+  return rp(verifyTokenOptions)
+    .then(response => {
+      // Verify the token’s channelId match with my channelId to prevent spoof attack
+      // <IMPORTANT> As LINE's Get user profiles API response doesn't include channelID,
+      // you must not skip this step to make sure that the LINE access token is indeed
+      // issued for your channel.
+      //TODO: consider !== here
+      if (response.channelId != config.line.channelId)
+        return Promise.reject(new Error('LINE channel ID mismatched'));
+
+      // STEP 2: Access token validation succeeded, so look up the corresponding Firebase user
+      const lineMid = response.mid;
+      return getFirebaseUser(lineMid, lineAccessToken);
+    })
+    .then(userRecord => {
+      // STEP 3: Generate Firebase Custom Auth Token
+      const tokenPromise = admin.auth().createCustomToken(userRecord.uid);
+      tokenPromise.then(token => {
+        console.log('Created Custom token for UID "', userRecord.uid, '" Token:', token);
+      });
+      
+      return tokenPromise;
+    });
 }
 
 // ExpressJS setup
@@ -55,35 +142,21 @@ app.post('/verifyToken', (req, res) => {
 
   const reqToken = req.body.token;
 
-  // Send request to LINE server for access token verification
-  const options = {
-    url: 'https://api.line.me/v1/oauth/verify',
-    headers: {
-      'Authorization': `Bearer ${reqToken}`
-    }
-  };
-  request(options, (error, response, body) => {
-    console.log(body);
-    if (!error && response.statusCode == 200) {
-      const lineObj = JSON.parse(body);
-
-      // Verify the token’s channelId match with my channelId to prevent spoof attack
-      if ((typeof lineObj.mid !== 'undefined') && (lineObj.channelId == config.line.channelId)) {
-        // Access Token Validation succeed with LINE server
-        // Generate Firebase token and return to device
-        const firebaseToken = generateFirebaseToken(lineObj.mid);
-        const ret = {
-          firebase_token: firebaseToken
-        };
-        return res.status(200).send(ret);    
-      }
-    }
-      
-    const ret = {
-      error_message: 'Authentication error: Cannot verify access token.'
-    };
-    return res.status(403).send(ret);
-  });
+  // Verify LINE access token with LINE server then generate Firebase Custom Auth token
+  verifyLineToken(reqToken)
+    .then(customAuthToken => {
+      const ret = {
+        firebase_token: customAuthToken
+      };
+      return res.status(200).send(ret);   
+    })
+    .catch(err => {
+      // If LINE access token verification failed, return error response to client
+      const ret = {
+        error_message: 'Authentication error: Cannot verify access token.'
+      };
+      return res.status(403).send(ret);
+    });
 
 });
 

--- a/Line/server/package.json
+++ b/Line/server/package.json
@@ -13,8 +13,9 @@
     "deploy": "gcloud app deploy"
   },
   "dependencies": {
-    "firebase": "^3.4.0",
-    "request": "^2.75.0",
+    "firebase-admin": "^4.0.0",
+    "request-promise": "^4.1.1",
+    "request": "^2.34",
     "express": "^4.14.0",
     "body-parser": "^1.15.0"
   }


### PR DESCRIPTION
## Changes made:
* Update server-side module to use firebase-admin SDK
* Fetch LINE profile to create Firebase user profile from server-side instead of client-side
* Remove LINE profile fetching from client app (iOS & Android)

@nicolasgarnier As changes in iOS & Android code are only removing LINE profile fetching code that has been migrated to server-side, I think having you review server-side changes is enough. What do you think?